### PR TITLE
Smg fix illegal exception

### DIFF
--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGBuiltins.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGBuiltins.java
@@ -22,12 +22,12 @@ import org.sosy_lab.cpachecker.cfa.ast.c.CRightHandSide;
 import org.sosy_lab.cpachecker.cfa.model.CFAEdge;
 import org.sosy_lab.cpachecker.cfa.types.MachineModel;
 import org.sosy_lab.cpachecker.cfa.types.c.CNumericTypes;
-import org.sosy_lab.cpachecker.cfa.types.c.CSimpleType;
 import org.sosy_lab.cpachecker.cfa.types.c.CType;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGAddressValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGExplicitValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGRightHandSideEvaluator;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGType;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.edge.SMGEdgePointsTo;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGNullObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
@@ -634,13 +634,9 @@ public class SMGBuiltins {
 
           if (!targetObject.isUnknown() && !sourceObject.isUnknown()) {
             CType expressionType = sizeExpr.getExpressionType();
-            int symbolicValueSize =
-                expressionEvaluator.getBitSizeof(pCfaEdge, expressionType, currentState);
-            boolean isSigned = false;
-            if (expressionType instanceof CSimpleType) {
-              CSimpleType simpleType = (CSimpleType) expressionType;
-              isSigned = machineModel.isSigned(simpleType);
-            }
+            SMGType symbolicValueSMGType =
+                SMGType.constructSMGType(
+                    expressionType, currentState, pCfaEdge, expressionEvaluator);
             for (SMGValueAndState sizeSymbolicValueAndState :
                 evaluateExpressionValue(currentState, pCfaEdge, sizeExpr)) {
               SMGSymbolicValue symbolicValue = sizeSymbolicValueAndState.getObject();
@@ -657,19 +653,15 @@ public class SMGBuiltins {
                 if (!currentState.getHeap().isObjectExternallyAllocated(sourceObject.getObject())) {
                   currentState.addErrorPredicate(
                       symbolicValue,
-                      symbolicValueSize,
-                      isSigned,
+                      symbolicValueSMGType,
                       SMGKnownExpValue.valueOf(availableSource),
-                      symbolicValueSize,
                       pCfaEdge);
                 }
                 if (!currentState.getHeap().isObjectExternallyAllocated(targetObject.getObject())) {
                   currentState.addErrorPredicate(
                       symbolicValue,
-                      symbolicValueSize,
-                      isSigned,
+                      symbolicValueSMGType,
                       SMGKnownExpValue.valueOf(availableTarget),
-                      symbolicValueSize,
                       pCfaEdge);
                 }
               }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGBuiltins.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGBuiltins.java
@@ -36,7 +36,6 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
@@ -163,7 +162,7 @@ public class SMGBuiltins {
       CFAEdge cfaEdge,
       SMGAddressValue bufferAddress,
       SMGExplicitValue countValue,
-      SMGSymbolicValue ch,
+      SMGValue ch,
       SMGExplicitValue expValue)
       throws CPATransferException {
 
@@ -639,7 +638,7 @@ public class SMGBuiltins {
                     expressionType, currentState, pCfaEdge, expressionEvaluator);
             for (SMGValueAndState sizeSymbolicValueAndState :
                 evaluateExpressionValue(currentState, pCfaEdge, sizeExpr)) {
-              SMGSymbolicValue symbolicValue = sizeSymbolicValueAndState.getObject();
+              SMGValue symbolicValue = sizeSymbolicValueAndState.getObject();
 
               int sourceRangeOffset = sourceObject.getOffset().getAsInt() / machineModel.getSizeofCharInBits();
               int sourceSize = sourceObject.getObject().getSize() / machineModel.getSizeofCharInBits();
@@ -864,8 +863,8 @@ public class SMGBuiltins {
           symFirstValueAndState
               .getSmgState()
               .readValue(secondRegion, offset, machineModel.getSizeofCharInBits());
-      SMGSymbolicValue symFirstValue = symFirstValueAndState.getObject();
-      SMGSymbolicValue symSecondValue = symSecondValueAndState.getObject();
+      SMGValue symFirstValue = symFirstValueAndState.getObject();
+      SMGValue symSecondValue = symSecondValueAndState.getObject();
       state = symSecondValueAndState.getSmgState();
       if (!bothValuesAreDefined(symFirstValue, symSecondValue)) {
         return SMGValueAndState.of(pState, SMGUnknownValue.INSTANCE);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
@@ -214,6 +214,7 @@ public class SMGPredicateManager {
         SMGKnownExpValue explicitValue = expValueEntry.getValue();
         BitvectorFormula valueFormula = createdValueFormulas.get(symbolicValue);
         SMGType symbolicType = valueTypes.get(symbolicValue);
+        valueFormula = cast(valueFormula, symbolicType, symbolicType);
         BooleanFormula equality =
             fmgr.makeEqual(
                 valueFormula,

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
@@ -189,7 +189,7 @@ public class SMGPredicateManager {
   public BooleanFormula getPathPredicateFormula(UnmodifiableSMGState pState) {
     SMGPredicateRelation pRelation = pState.getPathPredicateRelation();
     BooleanFormula predicateFormula = getPredicateFormula(pRelation, true);
-    predicateFormula = addExplicitFromState(predicateFormula, pState);
+    predicateFormula = fmgr.makeAnd(predicateFormula, getExplicitFormulaFromState(pState));
     return predicateFormula;
   }
 
@@ -197,13 +197,12 @@ public class SMGPredicateManager {
       SMGPredicateRelation pErrorPredicate, UnmodifiableSMGState pState) {
     BooleanFormula errorFormula = getPredicateFormula(pErrorPredicate, false);
     BooleanFormula pathFormula = getPathPredicateFormula(pState);
-    pathFormula = addExplicitFromState(pathFormula, pState);
+    pathFormula = fmgr.makeAnd(pathFormula, getExplicitFormulaFromState(pState));
     return fmgr.makeAnd(pathFormula, errorFormula);
   }
 
-  private BooleanFormula addExplicitFromState(
-      BooleanFormula pFormula, UnmodifiableSMGState pState) {
-    BooleanFormula result = pFormula;
+  private BooleanFormula getExplicitFormulaFromState(UnmodifiableSMGState pState) {
+    BooleanFormula result = bfmgr.makeBoolean(true);
     SMGPredicateRelation errorPredicateRelation = pState.getErrorPredicateRelation();
     SMGPredicateRelation pathPredicateRelation = pState.getPathPredicateRelation();
     for (Entry<SMGKnownSymbolicValue, SMGKnownExpValue> expValueEntry :

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
@@ -108,7 +108,9 @@ public class SMGPredicateManager {
     String nameOne = SYM_NAME + pRelation.getFirstValue();
     String nameTwo = SYM_NAME + pRelation.getSecondValue();
     Integer firstSize = pPredRelation.getSymbolicSize(pRelation.getFirstValue());
+    boolean isFirstSigned = pPredRelation.isSymbolicSigned(pRelation.getFirstValue());
     Integer secondSize = pPredRelation.getSymbolicSize(pRelation.getSecondValue());
+    boolean isSecondSigned = pPredRelation.isSymbolicSigned(pRelation.getSecondValue());
     BitvectorFormula formulaOne;
     BitvectorFormula formulaTwo;
     // Special case for NULL value
@@ -118,17 +120,21 @@ public class SMGPredicateManager {
     } else {
       formulaOne = efmgr.makeVariable(firstSize, nameOne);
     }
+    formulaOne = efmgr.extend(formulaOne, 0, isFirstSigned);
+
     if (pRelation.getSecondValue().isZero()) {
       secondSize = firstSize;
       formulaTwo = efmgr.makeBitvector(firstSize, 0);
     } else {
       formulaTwo = efmgr.makeVariable(secondSize, nameTwo);
     }
+    formulaTwo = efmgr.extend(formulaTwo, 0, isSecondSigned);
+
     if (!firstSize.equals(secondSize)) {
       if (firstSize > secondSize) {
-        formulaTwo = efmgr.extend(formulaTwo, firstSize - secondSize, true);
+        formulaTwo = efmgr.extend(formulaTwo, firstSize - secondSize, isSecondSigned);
       } else {
-        formulaOne = efmgr.extend(formulaOne, secondSize - firstSize, true);
+        formulaOne = efmgr.extend(formulaOne, secondSize - firstSize, isFirstSigned);
       }
     }
     BinaryOperator op = pRelation.getOperator();

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGPredicateManager.java
@@ -233,7 +233,7 @@ public class SMGPredicateManager {
     }
 
     for (Entry<Pair<SMGValue, SMGValue>, SymbolicRelation> entry : pRelation.getValuesRelations()) {
-      if (entry.getKey().getSecond().compareTo(entry.getKey().getFirst()) > 0) {
+      if (entry.getKey().getSecond().compareTo(entry.getKey().getFirst()) >= 0) {
         SymbolicRelation value = entry.getValue();
         result = addPredicateToFormula(result, value, conjunction);
       }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
@@ -46,8 +46,9 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGAd
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.CLangSMG;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.CLangSMGConsistencyVerifier;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.PredRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGHasValueEdges;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredRelation;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGType;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.UnmodifiableCLangSMG;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.edge.SMGEdgeHasValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.edge.SMGEdgeHasValueFilter;
@@ -1864,13 +1865,9 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
 
   public void addPredicateRelation(
       SMGSymbolicValue pV1,
-      int pSize1,
-      boolean pIsSigned1,
-      boolean pIsCast1,
+      SMGType pSMGType1,
       SMGSymbolicValue pV2,
-      int pSize2,
-      boolean pIsSigned2,
-      boolean pIsCast2,
+      SMGType pSMGType2,
       BinaryOperator pOp,
       CFAEdge pEdge) {
   if (isTrackPredicatesEnabled() && pEdge instanceof CAssumeEdge) {
@@ -1882,17 +1879,14 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
     }
       logger.logf(
           Level.FINER, "SymValue1 %s %s SymValue2 %s AddPredicate: %s", pV1, temp, pV2, pEdge);
-      getPathPredicateRelation()
-          .addRelation(pV1, pSize1, pIsSigned1, pIsCast1, pV2, pSize2, pIsSigned2, pIsCast2, temp);
+      getPathPredicateRelation().addRelation(pV1, pSMGType1, pV2, pSMGType2, temp);
   }
 }
 
   public void addPredicateRelation(
       SMGSymbolicValue pV1,
-      int pSize1,
-      boolean pSigned,
+      SMGType pSMGType1,
       SMGExplicitValue pV2,
-      int pSize2,
       BinaryOperator pOp,
       CFAEdge pEdge) {
     if (isTrackPredicatesEnabled() && pEdge instanceof CAssumeEdge) {
@@ -1904,21 +1898,19 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
       }
       logger.logf(
           Level.FINER, "SymValue %s %s; ExplValue %s; AddPredicate: %s", pV1, temp, pV2, pEdge);
-      getPathPredicateRelation().addExplicitRelation(pV1, pSize1, pSigned, pV2, pSize2, temp);
+      getPathPredicateRelation().addExplicitRelation(pV1, pSMGType1, pV2, temp);
     }
   }
 
   @Override
-  public PredRelation getPathPredicateRelation() {
+  public SMGPredRelation getPathPredicateRelation() {
     return heap.getPathPredicateRelation();
   }
 
   public void addErrorPredicate(
       SMGSymbolicValue pSymbolicValue,
-      Integer pSize1,
-      boolean isSigned,
+      SMGType pSymbolicSMGType,
       SMGExplicitValue pExplicitValue,
-      Integer pSize2,
       CFAEdge pEdge) {
     if (isTrackPredicatesEnabled()) {
       logger.log(Level.FINER, "Add Error Predicate: SymValue  ",
@@ -1926,17 +1918,12 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
           pExplicitValue, "; on edge: ", pEdge);
       getErrorPredicateRelation()
           .addExplicitRelation(
-              pSymbolicValue,
-              pSize1,
-              isSigned,
-              pExplicitValue,
-              pSize2,
-              BinaryOperator.GREATER_THAN);
+              pSymbolicValue, pSymbolicSMGType, pExplicitValue, BinaryOperator.GREATER_THAN);
     }
   }
 
   @Override
-  public PredRelation getErrorPredicateRelation() {
+  public SMGPredRelation getErrorPredicateRelation() {
     return heap.getErrorPredicateRelation();
   }
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
@@ -645,8 +645,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
             SMGEdgeHasValueFilter.objectFilter(pListSeg)
                 .filterAtOffset(nfo)
                 .filterBySize(sizeOfVoidPointerInBits));
-    SMGSymbolicValue oldPointerToRegion =
-        readValue(pListSeg, nfo, sizeOfVoidPointerInBits).getObject();
+    SMGValue oldPointerToRegion = readValue(pListSeg, nfo, sizeOfVoidPointerInBits).getObject();
     if (!oldSllFieldsToOldRegion.isEmpty()) {
       SMGEdgeHasValue oldSllFieldToOldRegion = Iterables.getOnlyElement(oldSllFieldsToOldRegion);
       heap.removeHasValueEdge(oldSllFieldToOldRegion);
@@ -766,7 +765,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
             SMGEdgeHasValueFilter.objectFilter(pListSeg)
                 .filterAtOffset(offsetPointingToRegion)
                 .filterWithoutSize());
-    SMGSymbolicValue oldPointerToRegion =
+    SMGValue oldPointerToRegion =
         readValue(pListSeg, offsetPointingToRegion, sizeOfVoidPointerInBits).getObject();
     if (!oldDllFieldsToOldRegion.isEmpty()) {
       SMGEdgeHasValue oldDllFieldToOldRegion = Iterables.getOnlyElement(oldDllFieldsToOldRegion);
@@ -1127,7 +1126,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
         stateAndNewEdge = writeValue0(pObject, pOffset, sizeInBits, newValue);
       }
       return SMGValueAndState.of(
-          stateAndNewEdge.getState(), (SMGSymbolicValue) stateAndNewEdge.getNewEdge().getValue());
+          stateAndNewEdge.getState(), stateAndNewEdge.getNewEdge().getValue());
     } else {
       return valueAndState;
     }
@@ -1170,7 +1169,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
       SMGEdgeHasValue object_edge = Iterables.getOnlyElement(matchingEdges);
       performConsistencyCheck(SMGRuntimeCheck.HALF);
       addElementToCurrentChain(object_edge);
-      return SMGValueAndState.of(this, (SMGSymbolicValue) object_edge.getValue());
+      return SMGValueAndState.of(this, object_edge.getValue());
     }
 
     SMGEdgeHasValue edge =
@@ -1201,10 +1200,10 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
    * @return the edge and the new state (may be this state)
    */
   public SMGStateEdgePair writeValue(
-      SMGObject pObject, long pOffset, long pSizeInBits, SMGSymbolicValue pValue)
+      SMGObject pObject, long pOffset, long pSizeInBits, SMGValue pValue)
       throws SMGInconsistentException {
 
-    SMGSymbolicValue value;
+    SMGValue value;
 
     // If the value is not yet known by the SMG
     // create a unconstrained new symbolic value
@@ -1864,9 +1863,9 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
   }
 
   public void addPredicateRelation(
-      SMGSymbolicValue pV1,
+      SMGValue pV1,
       SMGType pSMGType1,
-      SMGSymbolicValue pV2,
+      SMGValue pV2,
       SMGType pSMGType2,
       BinaryOperator pOp,
       CFAEdge pEdge) {
@@ -1884,11 +1883,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
 }
 
   public void addPredicateRelation(
-      SMGSymbolicValue pV1,
-      SMGType pSMGType1,
-      SMGExplicitValue pV2,
-      BinaryOperator pOp,
-      CFAEdge pEdge) {
+      SMGValue pV1, SMGType pSMGType1, SMGExplicitValue pV2, BinaryOperator pOp, CFAEdge pEdge) {
     if (isTrackPredicatesEnabled() && pEdge instanceof CAssumeEdge) {
       BinaryOperator temp;
       if (((CAssumeEdge) pEdge).getTruthAssumption()) {
@@ -1908,7 +1903,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
   }
 
   public void addErrorPredicate(
-      SMGSymbolicValue pSymbolicValue,
+      SMGValue pSymbolicValue,
       SMGType pSymbolicSMGType,
       SMGExplicitValue pExplicitValue,
       CFAEdge pEdge) {
@@ -2008,7 +2003,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
   }
 
   @Override
-  public boolean areNonEqual(SMGSymbolicValue pValue1, SMGSymbolicValue pValue2) {
+  public boolean areNonEqual(SMGValue pValue1, SMGValue pValue2) {
 
     if (pValue1.isUnknown() || pValue2.isUnknown() || pValue1.equals(pValue2)) {
       return false;

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
@@ -1866,9 +1866,11 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
       SMGSymbolicValue pV1,
       int pSize1,
       boolean pIsSigned1,
+      boolean pIsCast1,
       SMGSymbolicValue pV2,
       int pSize2,
       boolean pIsSigned2,
+      boolean pIsCast2,
       BinaryOperator pOp,
       CFAEdge pEdge) {
   if (isTrackPredicatesEnabled() && pEdge instanceof CAssumeEdge) {
@@ -1881,7 +1883,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
       logger.logf(
           Level.FINER, "SymValue1 %s %s SymValue2 %s AddPredicate: %s", pV1, temp, pV2, pEdge);
       getPathPredicateRelation()
-          .addRelation(pV1, pSize1, pIsSigned1, pV2, pSize2, pIsSigned2, temp);
+          .addRelation(pV1, pSize1, pIsSigned1, pIsCast1, pV2, pSize2, pIsSigned2, pIsCast2, temp);
   }
 }
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
@@ -1862,9 +1862,15 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
     return options.trackPredicates();
   }
 
-  public void addPredicateRelation(SMGSymbolicValue pV1, int pCType1,
-                                   SMGSymbolicValue pV2, int pCType2,
-                                   BinaryOperator pOp, CFAEdge pEdge) {
+  public void addPredicateRelation(
+      SMGSymbolicValue pV1,
+      int pSize1,
+      boolean pIsSigned1,
+      SMGSymbolicValue pV2,
+      int pSize2,
+      boolean pIsSigned2,
+      BinaryOperator pOp,
+      CFAEdge pEdge) {
   if (isTrackPredicatesEnabled() && pEdge instanceof CAssumeEdge) {
     BinaryOperator temp;
     if (((CAssumeEdge) pEdge).getTruthAssumption()) {
@@ -1874,13 +1880,19 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
     }
       logger.logf(
           Level.FINER, "SymValue1 %s %s SymValue2 %s AddPredicate: %s", pV1, temp, pV2, pEdge);
-      getPathPredicateRelation().addRelation(pV1, pCType1, pV2, pCType2, temp);
+      getPathPredicateRelation()
+          .addRelation(pV1, pSize1, pIsSigned1, pV2, pSize2, pIsSigned2, temp);
   }
 }
 
-  public void addPredicateRelation(SMGSymbolicValue pV1, int pCType1,
-                                   SMGExplicitValue pV2, int pCType2,
-                                   BinaryOperator pOp, CFAEdge pEdge) {
+  public void addPredicateRelation(
+      SMGSymbolicValue pV1,
+      int pSize1,
+      boolean pSigned,
+      SMGExplicitValue pV2,
+      int pSize2,
+      BinaryOperator pOp,
+      CFAEdge pEdge) {
     if (isTrackPredicatesEnabled() && pEdge instanceof CAssumeEdge) {
       BinaryOperator temp;
       if (((CAssumeEdge) pEdge).getTruthAssumption()) {
@@ -1890,7 +1902,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
       }
       logger.logf(
           Level.FINER, "SymValue %s %s; ExplValue %s; AddPredicate: %s", pV1, temp, pV2, pEdge);
-      getPathPredicateRelation().addExplicitRelation(pV1, pCType1, pV2, pCType2, temp);
+      getPathPredicateRelation().addExplicitRelation(pV1, pSize1, pSigned, pV2, pSize2, temp);
     }
   }
 
@@ -1899,16 +1911,25 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
     return heap.getPathPredicateRelation();
   }
 
-  public void addErrorPredicate(SMGSymbolicValue pSymbolicValue, Integer pCType1,
-                                SMGExplicitValue pExplicitValue, Integer pCType2,
-                                CFAEdge pEdge) {
+  public void addErrorPredicate(
+      SMGSymbolicValue pSymbolicValue,
+      Integer pSize1,
+      boolean isSigned,
+      SMGExplicitValue pExplicitValue,
+      Integer pSize2,
+      CFAEdge pEdge) {
     if (isTrackPredicatesEnabled()) {
       logger.log(Level.FINER, "Add Error Predicate: SymValue  ",
           pSymbolicValue, " ; ExplValue", " ",
           pExplicitValue, "; on edge: ", pEdge);
       getErrorPredicateRelation()
           .addExplicitRelation(
-              pSymbolicValue, pCType1, pExplicitValue, pCType2, BinaryOperator.GREATER_THAN);
+              pSymbolicValue,
+              pSize1,
+              isSigned,
+              pExplicitValue,
+              pSize2,
+              BinaryOperator.GREATER_THAN);
     }
   }
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGState.java
@@ -47,7 +47,7 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGVa
 import org.sosy_lab.cpachecker.cpa.smg.graphs.CLangSMG;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.CLangSMGConsistencyVerifier;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGHasValueEdges;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredRelation;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredicateRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGType;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.UnmodifiableCLangSMG;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.edge.SMGEdgeHasValue;
@@ -1903,7 +1903,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
   }
 
   @Override
-  public SMGPredRelation getPathPredicateRelation() {
+  public SMGPredicateRelation getPathPredicateRelation() {
     return heap.getPathPredicateRelation();
   }
 
@@ -1923,7 +1923,7 @@ public class SMGState implements UnmodifiableSMGState, AbstractQueryableState, G
   }
 
   @Override
-  public SMGPredRelation getErrorPredicateRelation() {
+  public SMGPredicateRelation getErrorPredicateRelation() {
     return heap.getErrorPredicateRelation();
   }
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
@@ -88,7 +88,6 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGEx
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGExpressionEvaluator;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGRightHandSideEvaluator;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredicateRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGRegion;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
@@ -98,6 +97,7 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.cpa.smg.refiner.SMGPrecision;
 import org.sosy_lab.cpachecker.exceptions.CPATransferException;
@@ -268,10 +268,9 @@ public class SMGTransferRelation
       CExpression lValue = funcAssignment.getLeftHandSide();
       CType rValueType = TypeUtils.getRealExpressionType(funcAssignment.getRightHandSide());
       SMGObject tmpMemory = newState.getHeap().getFunctionReturnObject();
-      SMGSymbolicValue rValue =
+      SMGValue rValue =
           expressionEvaluator
-              .readValue(
-                  newState, tmpMemory, SMGZeroValue.INSTANCE, rValueType, functionReturnEdge)
+              .readValue(newState, tmpMemory, SMGZeroValue.INSTANCE, rValueType, functionReturnEdge)
               .getObject();
 
       // Lvalue is one frame above
@@ -328,8 +327,8 @@ public class SMGTransferRelation
     }
 
     SMGState initialNewState = state.copyOf();
-    Map<UnmodifiableSMGState, List<Pair<SMGRegion, SMGSymbolicValue>>> valuesMap = new LinkedHashMap<>();
-    List<Pair<SMGRegion, SMGSymbolicValue>> initialValuesList = new ArrayList<>();
+    Map<UnmodifiableSMGState, List<Pair<SMGRegion, SMGValue>>> valuesMap = new LinkedHashMap<>();
+    List<Pair<SMGRegion, SMGValue>> initialValuesList = new ArrayList<>();
     valuesMap.put(initialNewState, initialValuesList);
     List<SMGState> newStates =
         evaluateArgumentValues(callEdge, arguments, paramDecl, initialNewState, valuesMap);
@@ -351,7 +350,7 @@ public class SMGTransferRelation
       List<CExpression> arguments,
       List<CParameterDeclaration> paramDecl,
       SMGState initialNewState,
-      Map<UnmodifiableSMGState, List<Pair<SMGRegion, SMGSymbolicValue>>> valuesMap)
+      Map<UnmodifiableSMGState, List<Pair<SMGRegion, SMGValue>>> valuesMap)
       throws CPATransferException {
 
     List<SMGState> newStates = Collections.singletonList(initialNewState);
@@ -401,11 +400,10 @@ public class SMGTransferRelation
     return newStates;
   }
 
-
   /** read and evaluate one argument (at index <code>i</code>) and put it into the valuesMap. */
   private List<SMGState> evaluateArgumentValue(
       CFunctionCallEdge callEdge,
-      Map<UnmodifiableSMGState, List<Pair<SMGRegion, SMGSymbolicValue>>> valuesMap,
+      Map<UnmodifiableSMGState, List<Pair<SMGRegion, SMGValue>>> valuesMap,
       int i,
       CExpression exp,
       SMGRegion paramObj,
@@ -418,7 +416,7 @@ public class SMGTransferRelation
 
     for (SMGValueAndState stateValue : readValueToBeAssiged(newState, callEdge, exp)) {
       SMGState newStateWithReadSymbolicValue = stateValue.getSmgState();
-      SMGSymbolicValue value = stateValue.getObject();
+      SMGValue value = stateValue.getObject();
 
       for (Pair<SMGState, SMGKnownSymbolicValue> newStateWithExpVal :
           assignExplicitValueToSymbolicValue(newStateWithReadSymbolicValue, callEdge, value, exp)) {
@@ -431,15 +429,15 @@ public class SMGTransferRelation
           valuesMap.put(curState, new ArrayList<>(valuesMap.get(newState)));
         }
 
-        final List<Pair<SMGRegion, SMGSymbolicValue>> curValues = valuesMap.get(curState);
+        final List<Pair<SMGRegion, SMGValue>> curValues = valuesMap.get(curState);
         assert curValues.size() == i : "evaluation of parameters out of order";
         curValues.add(i, Pair.of(paramObj, value));
 
         // Check that previous values are not merged with new one
         if (newStateWithExpVal.getSecond() != null) {
           for (int j = i - 1; j >= 0; j--) {
-            Pair<SMGRegion, SMGSymbolicValue> lhsCheckValuePair = curValues.get(j);
-            SMGSymbolicValue symbolicValue = lhsCheckValuePair.getSecond();
+            Pair<SMGRegion, SMGValue> lhsCheckValuePair = curValues.get(j);
+            SMGValue symbolicValue = lhsCheckValuePair.getSecond();
             if (newStateWithExpVal.getSecond().equals(symbolicValue)) {
               // Previous value was merged, replace with new value
               curValues.set(j, Pair.of(lhsCheckValuePair.getFirst(), value));
@@ -455,7 +453,7 @@ public class SMGTransferRelation
   private void assignParameterValues(
       CFunctionCallEdge callEdge,
       List<CParameterDeclaration> paramDecl,
-      List<Pair<SMGRegion, SMGSymbolicValue>> values,
+      List<Pair<SMGRegion, SMGValue>> values,
       SMGState newState)
       throws SMGInconsistentException, UnrecognizedCodeException {
 
@@ -474,7 +472,7 @@ public class SMGTransferRelation
       }
 
       SMGRegion newObject = values.get(i).getFirst();
-      SMGSymbolicValue symbolicValue = values.get(i).getSecond();
+      SMGValue symbolicValue = values.get(i).getSecond();
       int typeSize = expressionEvaluator.getBitSizeof(callEdge, cParamType, newState);
 
       newState.addLocalVariable(typeSize, varName, newObject);
@@ -521,7 +519,7 @@ public class SMGTransferRelation
     List<SMGState> result = new ArrayList<>();
     for (SMGValueAndState valueAndState : expression.accept(visitor)) {
 
-      SMGSymbolicValue value = valueAndState.getObject();
+      SMGValue value = valueAndState.getObject();
       state = valueAndState.getSmgState();
 
       if (!value.isUnknown()) {
@@ -556,8 +554,8 @@ public class SMGTransferRelation
     boolean impliesEqOn = visitor.impliesEqOn(truthValue, state);
     boolean impliesNeqOn = visitor.impliesNeqOn(truthValue, state);
 
-    SMGSymbolicValue val1ImpliesOn;
-    SMGSymbolicValue val2ImpliesOn;
+    SMGValue val1ImpliesOn;
+    SMGValue val2ImpliesOn;
 
     if(impliesEqOn || impliesNeqOn ) {
       val1ImpliesOn = visitor.impliesVal1(state);
@@ -592,9 +590,7 @@ public class SMGTransferRelation
         }
 
         newState = expressionEvaluator.deriveFurtherInformation(newState, truthValue, cfaEdge, expression);
-        SMGPredicateRelation pathPredicateRelation = newState.getPathPredicateRelation();
-        BooleanFormula predicateFormula =
-            smgPredicateManager.getPredicateFormula(pathPredicateRelation, newState);
+        BooleanFormula predicateFormula = smgPredicateManager.getPathPredicateFormula(newState);
         try {
           if (newState.hasMemoryErrors() || !smgPredicateManager.isUnsat(predicateFormula)) {
             result.add(newState);
@@ -782,7 +778,7 @@ public class SMGTransferRelation
     List<SMGValueAndState> resultValueAndStates = new ArrayList<>();
     for (SMGValueAndState valueAndState :
         expressionEvaluator.evaluateExpressionValue(pNewState, cfaEdge, rValue)) {
-      SMGSymbolicValue value = valueAndState.getObject();
+      SMGValue value = valueAndState.getObject();
 
       if (value.isUnknown()) {
         value = SMGKnownSymValue.of();
@@ -821,7 +817,7 @@ public class SMGTransferRelation
                   newState, cfaEdge, memoryOfField, fieldOffset, symbolicValue, rValueType));
         } else {
           for (SMGValueAndState valueAndState : readValueToBeAssiged(newState, cfaEdge, rValue)) {
-            SMGSymbolicValue value = valueAndState.getObject();
+            SMGValue value = valueAndState.getObject();
             SMGState curState = valueAndState.getSmgState();
 
             curState.putExplicit((SMGKnownSymbolicValue) value, (SMGKnownExpValue) expValue);
@@ -832,7 +828,7 @@ public class SMGTransferRelation
         }
       } else {
         for (SMGValueAndState valueAndState : readValueToBeAssiged(newState, cfaEdge, rValue)) {
-          SMGSymbolicValue value = valueAndState.getObject();
+          SMGValue value = valueAndState.getObject();
           SMGState curState = valueAndState.getSmgState();
 
           // TODO (  cast expression)
@@ -855,9 +851,8 @@ public class SMGTransferRelation
 
   // Assign symbolic value to the explicit value calculated from pRvalue
   private List<Pair<SMGState, SMGKnownSymbolicValue>> assignExplicitValueToSymbolicValue(
-      SMGState pNewState, CFAEdge pCfaEdge, SMGSymbolicValue value, CRightHandSide pRValue)
+      SMGState pNewState, CFAEdge pCfaEdge, SMGValue value, CRightHandSide pRValue)
       throws CPATransferException {
-
 
     List<Pair<SMGState, SMGKnownSymbolicValue>> result = new ArrayList<>();
     SMGExpressionEvaluator expEvaluator = new SMGExpressionEvaluator(logger, machineModel);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
@@ -88,7 +88,7 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGEx
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGExpressionEvaluator;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGRightHandSideEvaluator;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredRelation;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredicateRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGRegion;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
@@ -592,7 +592,7 @@ public class SMGTransferRelation
         }
 
         newState = expressionEvaluator.deriveFurtherInformation(newState, truthValue, cfaEdge, expression);
-        SMGPredRelation pathPredicateRelation = newState.getPathPredicateRelation();
+        SMGPredicateRelation pathPredicateRelation = newState.getPathPredicateRelation();
         BooleanFormula predicateFormula = smgPredicateManager.getPredicateFormula(pathPredicateRelation);
         try {
           if (newState.hasMemoryErrors() || !smgPredicateManager.isUnsat(predicateFormula)) {

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
@@ -593,7 +593,8 @@ public class SMGTransferRelation
 
         newState = expressionEvaluator.deriveFurtherInformation(newState, truthValue, cfaEdge, expression);
         SMGPredicateRelation pathPredicateRelation = newState.getPathPredicateRelation();
-        BooleanFormula predicateFormula = smgPredicateManager.getPredicateFormula(pathPredicateRelation);
+        BooleanFormula predicateFormula =
+            smgPredicateManager.getPredicateFormula(pathPredicateRelation, newState);
         try {
           if (newState.hasMemoryErrors() || !smgPredicateManager.isUnsat(predicateFormula)) {
             result.add(newState);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/SMGTransferRelation.java
@@ -88,7 +88,7 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGEx
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGExpressionEvaluator;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGRightHandSideEvaluator;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.PredRelation;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGRegion;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
@@ -592,7 +592,7 @@ public class SMGTransferRelation
         }
 
         newState = expressionEvaluator.deriveFurtherInformation(newState, truthValue, cfaEdge, expression);
-        PredRelation pathPredicateRelation = newState.getPathPredicateRelation();
+        SMGPredRelation pathPredicateRelation = newState.getPathPredicateRelation();
         BooleanFormula predicateFormula = smgPredicateManager.getPredicateFormula(pathPredicateRelation);
         try {
           if (newState.hasMemoryErrors() || !smgPredicateManager.isUnsat(predicateFormula)) {

--- a/src/org/sosy_lab/cpachecker/cpa/smg/UnmodifiableSMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/UnmodifiableSMGState.java
@@ -163,7 +163,7 @@ public interface UnmodifiableSMGState extends LatticeAbstractState<UnmodifiableS
 
   boolean hasMemoryLeaks();
 
-  boolean areNonEqual(SMGSymbolicValue pValue1, SMGSymbolicValue pValue2);
+  boolean areNonEqual(SMGValue pValue1, SMGValue pValue2);
 
   SMGObject getObjectForFunction(CFunctionDeclaration pDeclaration);
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/UnmodifiableSMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/UnmodifiableSMGState.java
@@ -19,7 +19,7 @@ import org.sosy_lab.cpachecker.cfa.ast.c.CFunctionDeclaration;
 import org.sosy_lab.cpachecker.core.defaults.LatticeAbstractState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGAddressValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.CLangSMG;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.PredRelation;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.UnmodifiableCLangSMG;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGRegion;
@@ -151,9 +151,9 @@ public interface UnmodifiableSMGState extends LatticeAbstractState<UnmodifiableS
 
   boolean isTrackPredicatesEnabled();
 
-  PredRelation getPathPredicateRelation();
+  SMGPredRelation getPathPredicateRelation();
 
-  PredRelation getErrorPredicateRelation();
+  SMGPredRelation getErrorPredicateRelation();
 
   boolean isExplicit(SMGKnownSymbolicValue value);
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/UnmodifiableSMGState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/UnmodifiableSMGState.java
@@ -19,7 +19,7 @@ import org.sosy_lab.cpachecker.cfa.ast.c.CFunctionDeclaration;
 import org.sosy_lab.cpachecker.core.defaults.LatticeAbstractState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGAddressValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.CLangSMG;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredRelation;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGPredicateRelation;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.UnmodifiableCLangSMG;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGRegion;
@@ -151,9 +151,9 @@ public interface UnmodifiableSMGState extends LatticeAbstractState<UnmodifiableS
 
   boolean isTrackPredicatesEnabled();
 
-  SMGPredRelation getPathPredicateRelation();
+  SMGPredicateRelation getPathPredicateRelation();
 
-  SMGPredRelation getErrorPredicateRelation();
+  SMGPredicateRelation getErrorPredicateRelation();
 
   boolean isExplicit(SMGKnownSymbolicValue value);
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssigningValueVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssigningValueVisitor.java
@@ -35,7 +35,7 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.exceptions.CPATransferException;
 
@@ -149,7 +149,8 @@ class AssigningValueVisitor extends DefaultCExpressionVisitor<Void, CPATransferE
       return;
     }
 
-    SMGSymbolicValue rSymValue = smgRightHandSideEvaluator.evaluateExpressionValueV2(assignableState, edge, lValue);
+    SMGValue rSymValue =
+        smgRightHandSideEvaluator.evaluateExpressionValueV2(assignableState, edge, lValue);
 
     CType lValueType = TypeUtils.getRealExpressionType(lValue);
     if(rSymValue.isUnknown()) {
@@ -240,7 +241,8 @@ class AssigningValueVisitor extends DefaultCExpressionVisitor<Void, CPATransferE
     // If this value is known, the assumption can be evaluated, therefore it should be unknown
     assert smgRightHandSideEvaluator.evaluateExplicitValueV2(assignableState, edge, lValue).isUnknown();
 
-    SMGSymbolicValue value = smgRightHandSideEvaluator.evaluateExpressionValueV2(assignableState, edge, lValue);
+    SMGValue value =
+        smgRightHandSideEvaluator.evaluateExpressionValueV2(assignableState, edge, lValue);
 
     // This symbolic value should have been added when evaluating the assume
     assert !value.isUnknown();

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssigningValueVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssigningValueVisitor.java
@@ -25,6 +25,8 @@ import org.sosy_lab.cpachecker.cfa.ast.c.CUnaryExpression;
 import org.sosy_lab.cpachecker.cfa.ast.c.CUnaryExpression.UnaryOperator;
 import org.sosy_lab.cpachecker.cfa.ast.c.DefaultCExpressionVisitor;
 import org.sosy_lab.cpachecker.cfa.model.CFAEdge;
+import org.sosy_lab.cpachecker.cfa.types.c.CSimpleType;
+import org.sosy_lab.cpachecker.cfa.types.c.CType;
 import org.sosy_lab.cpachecker.cpa.smg.SMGState;
 import org.sosy_lab.cpachecker.cpa.smg.TypeUtils;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGAddressAndState;
@@ -149,6 +151,7 @@ class AssigningValueVisitor extends DefaultCExpressionVisitor<Void, CPATransferE
 
     SMGSymbolicValue rSymValue = smgRightHandSideEvaluator.evaluateExpressionValueV2(assignableState, edge, lValue);
 
+    CType lValueType = TypeUtils.getRealExpressionType(lValue);
     if(rSymValue.isUnknown()) {
 
       rSymValue = SMGKnownSymValue.of();
@@ -172,14 +175,17 @@ class AssigningValueVisitor extends DefaultCExpressionVisitor<Void, CPATransferE
               assignableState,
               addressOfField.getObject(),
               addressOfField.getOffset().getAsLong(),
-              TypeUtils.getRealExpressionType(lValue),
+              lValueType,
               rSymValue,
               edge);
     }
-    int size =
-        smgRightHandSideEvaluator.getBitSizeof(
-            edge, TypeUtils.getRealExpressionType(lValue), assignableState);
-    assignableState.addPredicateRelation(rSymValue, size, rValue, size, op, edge);
+    int size = smgRightHandSideEvaluator.getBitSizeof(edge, lValueType, assignableState);
+    boolean isSigned = false;
+    if (lValueType instanceof CSimpleType) {
+      CSimpleType simpleType = (CSimpleType) lValueType;
+      isSigned = assignableState.getHeap().getMachineModel().isSigned(simpleType);
+    }
+    assignableState.addPredicateRelation(rSymValue, size, isSigned, rValue, size, op, edge);
     if (truthValue) {
       if (op == BinaryOperator.EQUALS) {
         assignableState.putExplicit((SMGKnownSymbolicValue) rSymValue, (SMGKnownExpValue) rValue);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssigningValueVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssigningValueVisitor.java
@@ -25,11 +25,11 @@ import org.sosy_lab.cpachecker.cfa.ast.c.CUnaryExpression;
 import org.sosy_lab.cpachecker.cfa.ast.c.CUnaryExpression.UnaryOperator;
 import org.sosy_lab.cpachecker.cfa.ast.c.DefaultCExpressionVisitor;
 import org.sosy_lab.cpachecker.cfa.model.CFAEdge;
-import org.sosy_lab.cpachecker.cfa.types.c.CSimpleType;
 import org.sosy_lab.cpachecker.cfa.types.c.CType;
 import org.sosy_lab.cpachecker.cpa.smg.SMGState;
 import org.sosy_lab.cpachecker.cpa.smg.TypeUtils;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGAddressAndState;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGType;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
@@ -179,13 +179,9 @@ class AssigningValueVisitor extends DefaultCExpressionVisitor<Void, CPATransferE
               rSymValue,
               edge);
     }
-    int size = smgRightHandSideEvaluator.getBitSizeof(edge, lValueType, assignableState);
-    boolean isSigned = false;
-    if (lValueType instanceof CSimpleType) {
-      CSimpleType simpleType = (CSimpleType) lValueType;
-      isSigned = assignableState.getHeap().getMachineModel().isSigned(simpleType);
-    }
-    assignableState.addPredicateRelation(rSymValue, size, isSigned, rValue, size, op, edge);
+    SMGType symValueType =
+        SMGType.constructSMGType(lValueType, assignableState, edge, smgRightHandSideEvaluator);
+    assignableState.addPredicateRelation(rSymValue, symValueType, rValue, op, edge);
     if (truthValue) {
       if (op == BinaryOperator.EQUALS) {
         assignableState.putExplicit((SMGKnownSymbolicValue) rSymValue, (SMGKnownExpValue) rValue);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
@@ -25,9 +25,13 @@ import org.sosy_lab.cpachecker.cpa.smg.SMGState;
 import org.sosy_lab.cpachecker.cpa.smg.UnmodifiableSMGState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.SMGType;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGNullObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.exceptions.CPATransferException;
@@ -219,6 +223,22 @@ public class AssumeVisitor extends ExpressionValueVisitor {
         if (isPointerOp1 && isPointerOp2) {
           isTrue = comparePointer((SMGKnownAddressValue) pV1, (SMGKnownAddressValue) pV2, pOp);
           isFalse = !isTrue;
+        } else if (isPointerOp1 && !pV2.isUnknown()) {
+          SMGExplicitValue explicit2 = pNewState.getExplicit((SMGKnownSymbolicValue) pV2);
+          if (explicit2 != null) {
+            isTrue = comparePointer((SMGKnownAddressValue) pV1,
+                (SMGKnownAddressValue) SMGKnownAddressValue
+                    .valueOf((SMGKnownSymbolicValue) pV2, SMGNullObject.INSTANCE,
+                        (SMGKnownExpValue) explicit2), pOp);
+            isFalse = !isTrue;
+          }
+        } else if (isPointerOp2 && !pV1.isUnknown()) {
+            SMGExplicitValue explicit1 = pNewState.getExplicit((SMGKnownSymbolicValue) pV1);
+            if (explicit1 != null) {
+              isTrue = comparePointer((SMGKnownAddressValue) SMGKnownAddressValue.valueOf((SMGKnownSymbolicValue) pV1, SMGNullObject.INSTANCE,
+                      (SMGKnownExpValue) explicit1), (SMGKnownAddressValue) pV2, pOp);
+              isFalse = !isTrue;
+            }
         }
       break;
     default:

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import org.sosy_lab.cpachecker.cfa.ast.c.CBinaryExpression;
 import org.sosy_lab.cpachecker.cfa.ast.c.CBinaryExpression.BinaryOperator;
+import org.sosy_lab.cpachecker.cfa.ast.c.CCastExpression;
 import org.sosy_lab.cpachecker.cfa.ast.c.CExpression;
 import org.sosy_lab.cpachecker.cfa.model.CFAEdge;
 import org.sosy_lab.cpachecker.cfa.types.c.CSimpleType;
@@ -77,6 +78,7 @@ public class AssumeVisitor extends ExpressionValueVisitor {
               // TODO: separate modifiable and unmodifiable visitor
               CType leftSideType = leftSideExpression.getExpressionType();
               boolean isSignedLeft = false;
+              boolean isLeftSideCast = leftSideExpression instanceof CCastExpression;
               if (leftSideType instanceof CSimpleType) {
                 isSignedLeft =
                     newState.getHeap().getMachineModel().isSigned((CSimpleType) leftSideType);
@@ -85,6 +87,7 @@ public class AssumeVisitor extends ExpressionValueVisitor {
                   smgExpressionEvaluator.getBitSizeof(edge, leftSideType, newState);
               CType rightSideType = rightSideExpression.getExpressionType();
               boolean isSignedRight = false;
+              boolean isRightSideCast = rightSideExpression instanceof CCastExpression;
               if (rightSideType instanceof CSimpleType) {
                 isSignedRight =
                     newState.getHeap().getMachineModel().isSigned((CSimpleType) rightSideType);
@@ -95,9 +98,11 @@ public class AssumeVisitor extends ExpressionValueVisitor {
                   leftSideVal,
                   leftSideTypeSize,
                   isSignedLeft,
+                  isLeftSideCast,
                   rightSideVal,
                   rightSideTypeSize,
                   isSignedRight,
+                  isRightSideCast,
                   binaryOperator,
                   edge);
               result.add(SMGValueAndState.of(newState, resultValue));

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
@@ -83,9 +83,11 @@ public class AssumeVisitor extends ExpressionValueVisitor {
               CType leftSideType = leftSideExpression.getExpressionType();
               SMGType leftSideSMGType =
                   SMGType.constructSMGType(leftSideType, newState, edge, smgExpressionEvaluator);
-              if (leftSideExpression instanceof CCastExpression) {
+              while (leftSideExpression instanceof CCastExpression) {
+                //TODO: rewrite as list of castings
                 CCastExpression leftSideCastExpression = (CCastExpression) leftSideExpression;
-                CType leftSideOriginType = leftSideCastExpression.getOperand().getExpressionType();
+                leftSideExpression = leftSideCastExpression.getOperand();
+                CType leftSideOriginType = leftSideExpression.getExpressionType();
                 SMGType leftSideOriginSMGType =
                     SMGType.constructSMGType(
                         leftSideOriginType, newState, edge, smgExpressionEvaluator);
@@ -95,10 +97,10 @@ public class AssumeVisitor extends ExpressionValueVisitor {
               CType rightSideType = rightSideExpression.getExpressionType();
               SMGType rightSideSMGType =
                   SMGType.constructSMGType(rightSideType, newState, edge, smgExpressionEvaluator);
-              if (rightSideExpression instanceof CCastExpression) {
+              while (rightSideExpression instanceof CCastExpression) {
                 CCastExpression rightSideCastExpression = (CCastExpression) rightSideExpression;
-                CType rightSideOriginType =
-                    rightSideCastExpression.getOperand().getExpressionType();
+                rightSideExpression = rightSideCastExpression.getOperand();
+                CType rightSideOriginType = rightSideExpression.getExpressionType();
                 SMGType rightSideOriginSMGType =
                     SMGType.constructSMGType(
                         rightSideOriginType, newState, edge, smgExpressionEvaluator);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/AssumeVisitor.java
@@ -32,7 +32,7 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.exceptions.CPATransferException;
 
@@ -66,18 +66,18 @@ public class AssumeVisitor extends ExpressionValueVisitor {
         for (SMGValueAndState leftSideValAndState :
             smgExpressionEvaluator.evaluateExpressionValue(
                 getInitialSmgState(), edge, leftSideExpression)) {
-        SMGSymbolicValue leftSideVal = leftSideValAndState.getObject();
+          SMGValue leftSideVal = leftSideValAndState.getObject();
         SMGState newState = leftSideValAndState.getSmgState();
 
           for (SMGValueAndState rightSideValAndState :
               smgExpressionEvaluator.evaluateExpressionValue(newState, edge, rightSideExpression)) {
-          SMGSymbolicValue rightSideVal = rightSideValAndState.getObject();
+            SMGValue rightSideVal = rightSideValAndState.getObject();
           newState = rightSideValAndState.getSmgState();
 
             for (SMGValueAndState resultValueAndState :
                 evaluateBinaryAssumption(newState, binaryOperator, leftSideVal, rightSideVal)) {
               newState = resultValueAndState.getSmgState();
-              SMGSymbolicValue resultValue = resultValueAndState.getObject();
+              SMGValue resultValue = resultValueAndState.getObject();
 
               // TODO: separate modifiable and unmodifiable visitor
               CType leftSideType = leftSideExpression.getExpressionType();
@@ -122,7 +122,7 @@ public class AssumeVisitor extends ExpressionValueVisitor {
     }
   }
 
-  private boolean isPointer(UnmodifiableSMGState pNewSmgState, SMGSymbolicValue symVal) {
+  private boolean isPointer(UnmodifiableSMGState pNewSmgState, SMGValue symVal) {
 
     if (symVal.isUnknown()) {
       return false;
@@ -165,7 +165,7 @@ public class AssumeVisitor extends ExpressionValueVisitor {
   }
 
   private SMGValueAndState evaluateBinaryAssumptionOfConcreteSymbolicValues(
-      SMGState pNewState, BinaryOperator pOp, SMGSymbolicValue pV1, SMGSymbolicValue pV2) {
+      SMGState pNewState, BinaryOperator pOp, SMGValue pV1, SMGValue pV2) {
 
     boolean isPointerOp1 = pV1 instanceof SMGKnownAddressValue;
     boolean isPointerOp2 = pV2 instanceof SMGKnownAddressValue;
@@ -259,7 +259,7 @@ public class AssumeVisitor extends ExpressionValueVisitor {
   }
 
   public List<? extends SMGValueAndState> evaluateBinaryAssumption(
-      SMGState pNewState, BinaryOperator pOp, SMGSymbolicValue pV1, SMGSymbolicValue pV2)
+      SMGState pNewState, BinaryOperator pOp, SMGValue pV1, SMGValue pV2)
       throws SMGInconsistentException {
 
     // If a value is unknown, we can't make further assumptions about it.
@@ -270,10 +270,10 @@ public class AssumeVisitor extends ExpressionValueVisitor {
     ImmutableList.Builder<SMGValueAndState> result = ImmutableList.builderWithExpectedSize(4);
 
     for (SMGValueAndState operand1AndState : getOperand(pNewState, pV1)) {
-      SMGSymbolicValue operand1 = operand1AndState.getObject();
+      SMGValue operand1 = operand1AndState.getObject();
 
       for (SMGValueAndState operand2AndState : getOperand(pNewState, pV2)) {
-        SMGSymbolicValue operand2 = operand2AndState.getObject();
+        SMGValue operand2 = operand2AndState.getObject();
         SMGState newState = operand2AndState.getSmgState();
 
         SMGValueAndState resultValueAndState = evaluateBinaryAssumptionOfConcreteSymbolicValues(newState, pOp, operand1, operand2);
@@ -284,7 +284,7 @@ public class AssumeVisitor extends ExpressionValueVisitor {
     return result.build();
   }
 
-  private List<? extends SMGValueAndState> getOperand(SMGState pNewState, SMGSymbolicValue pV)
+  private List<? extends SMGValueAndState> getOperand(SMGState pNewState, SMGValue pV)
       throws SMGInconsistentException {
     if (isPointer(pNewState, pV)) {
       return smgExpressionEvaluator.getAddressFromSymbolicValue(SMGValueAndState.of(pNewState, pV));
@@ -307,11 +307,11 @@ public class AssumeVisitor extends ExpressionValueVisitor {
     return relations.get(pState).impliesNeq(pTruth);
   }
 
-  public SMGSymbolicValue impliesVal1(UnmodifiableSMGState pState) {
+  public SMGValue impliesVal1(UnmodifiableSMGState pState) {
     return relations.get(pState).getVal1();
   }
 
-  public SMGSymbolicValue impliesVal2(UnmodifiableSMGState pState) {
+  public SMGValue impliesVal2(UnmodifiableSMGState pState) {
     return relations.get(pState).getVal2();
   }
 
@@ -326,16 +326,15 @@ public class AssumeVisitor extends ExpressionValueVisitor {
     private final boolean impliesEqWhenFalse;
     private final boolean impliesNeqWhenFalse;
 
-    private final SMGSymbolicValue val1;
-    private final SMGSymbolicValue val2;
+    private final SMGValue val1;
+    private final SMGValue val2;
 
     /**
-     * Creates an object of the BinaryRelationResult. The object is used to
-     * determine the relation between two symbolic values in the context of
-     * the given smgState and the given binary operator. Note that the given
-     * symbolic values, which may also be address values, do not have to be
-     * part of the given Smg. The definition of an smg implies conditions for
-     * its values, even if they are not part of it.
+     * Creates an object of the BinaryRelationResult. The object is used to determine the relation
+     * between two symbolic values in the context of the given smgState and the given binary
+     * operator. Note that the given symbolic values, which may also be address values, do not have
+     * to be part of the given Smg. The definition of an smg implies conditions for its values, even
+     * if they are not part of it.
      *
      * @param pIsTrue boolean expression is true.
      * @param pIsFalse boolean expression is false
@@ -353,8 +352,8 @@ public class AssumeVisitor extends ExpressionValueVisitor {
         boolean pImpliesNeqWhenFalse,
         boolean pImpliesEqWhenTrue,
         boolean pImpliesNeqWhenTrue,
-        SMGSymbolicValue pVal1,
-        SMGSymbolicValue pVal2) {
+        SMGValue pVal1,
+        SMGValue pVal2) {
       isTrue = pIsTrue;
       isFalse = pIsFalse;
       impliesEqWhenFalse = pImpliesEqWhenFalse;
@@ -383,11 +382,11 @@ public class AssumeVisitor extends ExpressionValueVisitor {
       return pTruth ? impliesNeqWhenTrue : impliesNeqWhenFalse;
     }
 
-    SMGSymbolicValue getVal2() {
+    SMGValue getVal2() {
       return val2;
     }
 
-    SMGSymbolicValue getVal1() {
+    SMGValue getVal1() {
       return val1;
     }
   }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/ExplicitValueVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/ExplicitValueVisitor.java
@@ -26,8 +26,8 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGVa
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.cpa.value.AbstractExpressionValueVisitor;
 import org.sosy_lab.cpachecker.cpa.value.type.NumericValue;
@@ -81,7 +81,7 @@ class ExplicitValueVisitor extends AbstractExpressionValueVisitor {
     return smgStatesToBeProccessed;
   }
 
-  private SMGExplicitValue getExplicitValue(SMGSymbolicValue pValue) {
+  private SMGExplicitValue getExplicitValue(SMGValue pValue) {
     if (pValue.isUnknown()) {
       return SMGUnknownValue.INSTANCE;
     }
@@ -116,7 +116,7 @@ class ExplicitValueVisitor extends AbstractExpressionValueVisitor {
       }
 
       SMGValueAndState symValueAndState = getStateAndAddRestForLater(symValueAndStates);
-      SMGSymbolicValue symValue = symValueAndState.getObject();
+      SMGValue symValue = symValueAndState.getObject();
       setState(symValueAndState.getSmgState());
 
       if (symValue.equals(SMGKnownSymValue.TRUE)) {
@@ -150,7 +150,7 @@ class ExplicitValueVisitor extends AbstractExpressionValueVisitor {
     }
 
     SMGValueAndState valueAndState = getStateAndAddRestForLater(valueAndStates);
-    SMGSymbolicValue value = valueAndState.getObject();
+    SMGValue value = valueAndState.getObject();
     setState(valueAndState.getSmgState());
 
     SMGExplicitValue expValue = getExplicitValue(value);

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/ExpressionValueVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/ExpressionValueVisitor.java
@@ -50,6 +50,9 @@ import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGVa
 import org.sosy_lab.cpachecker.cpa.smg.graphs.object.SMGObject;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddressValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
@@ -115,10 +118,14 @@ class ExpressionValueVisitor
 
     BigInteger value = exp.getValue();
 
-    boolean isZero = value.equals(BigInteger.ZERO);
+    SMGKnownSymbolicValue symbolicOfExplicit =
+        getInitialSmgState().getSymbolicOfExplicit(SMGKnownExpValue.valueOf(value));
+    if (symbolicOfExplicit == null) {
+      symbolicOfExplicit = SMGKnownSymValue.of();
+      getInitialSmgState().putExplicit(symbolicOfExplicit, SMGKnownExpValue.valueOf(value));
+    }
 
-    SMGSymbolicValue val = (isZero ? SMGZeroValue.INSTANCE : SMGUnknownValue.INSTANCE);
-    return singletonList(SMGValueAndState.of(getInitialSmgState(), val));
+    return singletonList(SMGValueAndState.of(getInitialSmgState(), symbolicOfExplicit));
   }
 
   @Override

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/ForceExplicitValueVisitor.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/ForceExplicitValueVisitor.java
@@ -23,7 +23,7 @@ import org.sosy_lab.cpachecker.cpa.smg.SMGState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGAbstractObjectAndState.SMGValueAndState;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.value.type.NumericValue;
 import org.sosy_lab.cpachecker.cpa.value.type.Value;
 import org.sosy_lab.cpachecker.cpa.value.type.Value.UnknownValue;
@@ -105,7 +105,7 @@ class ForceExplicitValueVisitor extends ExplicitValueVisitor {
       throw e2;
     }
 
-    SMGSymbolicValue value = symbolicValueAndState.getObject();
+    SMGValue value = symbolicValueAndState.getObject();
     setState(symbolicValueAndState.getSmgState());
 
     if (value.isUnknown()) {

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGAbstractObjectAndState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGAbstractObjectAndState.java
@@ -45,7 +45,7 @@ public abstract class SMGAbstractObjectAndState<T> {
   }
 
   public static class SMGAddressValueAndState extends SMGValueAndState {
-    private SMGValue symbolicValue;
+    private final SMGValue symbolicValue;
 
     private SMGAddressValueAndState(
         SMGState pState, SMGAddressValue pValue, SMGValue pSymbolicValue) {

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGAbstractObjectAndState.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGAbstractObjectAndState.java
@@ -14,8 +14,8 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddressValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 
 /**
  * This class represents a simple Pair of an object and a state.
@@ -45,9 +45,12 @@ public abstract class SMGAbstractObjectAndState<T> {
   }
 
   public static class SMGAddressValueAndState extends SMGValueAndState {
+    private SMGValue symbolicValue;
 
-    private SMGAddressValueAndState(SMGState pState, SMGAddressValue pValue) {
+    private SMGAddressValueAndState(
+        SMGState pState, SMGAddressValue pValue, SMGValue pSymbolicValue) {
       super(pState, pValue);
+      symbolicValue = pSymbolicValue;
     }
 
     @Override
@@ -55,16 +58,25 @@ public abstract class SMGAbstractObjectAndState<T> {
       return (SMGAddressValue) super.getObject();
     }
 
+    public SMGValue getValue() {
+      return symbolicValue;
+    }
+
     public static SMGAddressValueAndState of(SMGState pState, SMGAddressValue pValue) {
-      return new SMGAddressValueAndState(pState, pValue);
+      return new SMGAddressValueAndState(pState, pValue, pValue);
     }
 
     public static SMGAddressValueAndState of(SMGState pState) {
       return of(pState, SMGUnknownValue.INSTANCE);
     }
 
+    public static SMGAddressValueAndState of(SMGState pState, SMGValue pValue) {
+      return new SMGAddressValueAndState(pState, SMGUnknownValue.INSTANCE, pValue);
+    }
+
     public static SMGAddressValueAndState of(SMGState pState, SMGEdgePointsTo pAddressValue) {
-      return of(pState, SMGKnownAddressValue.valueOf(pAddressValue));
+      return new SMGAddressValueAndState(
+          pState, SMGKnownAddressValue.valueOf(pAddressValue), pAddressValue.getValue());
     }
   }
 
@@ -83,9 +95,9 @@ public abstract class SMGAbstractObjectAndState<T> {
     }
   }
 
-  public static class SMGValueAndState extends SMGAbstractObjectAndState<SMGSymbolicValue> {
+  public static class SMGValueAndState extends SMGAbstractObjectAndState<SMGValue> {
 
-    private SMGValueAndState(SMGState pState, SMGSymbolicValue pValue) {
+    private SMGValueAndState(SMGState pState, SMGValue pValue) {
       super(pState, pValue);
     }
 
@@ -93,7 +105,7 @@ public abstract class SMGAbstractObjectAndState<T> {
       return of(pState, SMGUnknownValue.INSTANCE);
     }
 
-    public static SMGValueAndState of(SMGState pState, SMGSymbolicValue pValue) {
+    public static SMGValueAndState of(SMGState pState, SMGValue pValue) {
       return new SMGValueAndState(pState, pValue);
     }
   }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGExpressionEvaluator.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGExpressionEvaluator.java
@@ -52,8 +52,10 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddress;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGAddressValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGField;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
@@ -654,6 +656,17 @@ public class SMGExpressionEvaluator {
 
     if (pAddressValue.isUnknown()) {
       return singletonList(SMGAddressValueAndState.of(smgState));
+    }
+
+    SMGExplicitValue explicit = smgState.getExplicit((SMGKnownSymbolicValue) pAddressValue);
+    if (explicit != null && !explicit.isUnknown()) {
+      return singletonList(
+          SMGAddressValueAndState.of(
+              smgState,
+              SMGKnownAddressValue.valueOf(
+                  (SMGKnownSymbolicValue) pAddressValue,
+                  SMGNullObject.INSTANCE,
+                  (SMGKnownExpValue) explicit)));
     }
 
     if (!smgState.getHeap().isPointer(pAddressValue)) {

--- a/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGRightHandSideEvaluator.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/evaluator/SMGRightHandSideEvaluator.java
@@ -42,8 +42,8 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownExpValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownSymbolicValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGUnknownValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.value.type.Value;
 import org.sosy_lab.cpachecker.exceptions.CPATransferException;
 import org.sosy_lab.cpachecker.exceptions.UnrecognizedCodeException;
@@ -166,7 +166,7 @@ public class SMGRightHandSideEvaluator extends SMGExpressionEvaluator {
       SMGObject pMemoryOfField,
       long pFieldOffset,
       CType pRValueType,
-      SMGSymbolicValue pValue,
+      SMGValue pValue,
       CFAEdge pEdge)
       throws SMGInconsistentException, UnrecognizedCodeException {
 
@@ -230,7 +230,7 @@ public class SMGRightHandSideEvaluator extends SMGExpressionEvaluator {
       CFAEdge cfaEdge,
       SMGObject memoryOfField,
       long fieldOffset,
-      SMGSymbolicValue value,
+      SMGValue value,
       CType rValueType)
       throws UnrecognizedCodeException, SMGInconsistentException {
 
@@ -262,7 +262,7 @@ public class SMGRightHandSideEvaluator extends SMGExpressionEvaluator {
       SMGObject pMemoryOfField,
       long pFieldOffset,
       CType pRValueType,
-      SMGSymbolicValue pValue,
+      SMGValue pValue,
       CFAEdge pCfaEdge)
       throws SMGInconsistentException, UnrecognizedCodeException {
 
@@ -313,7 +313,7 @@ public class SMGRightHandSideEvaluator extends SMGExpressionEvaluator {
                       pCfaEdge,
                       object,
                       offset.getAsLong(),
-                      (SMGSymbolicValue) newParamValue.getValue(),
+                      newParamValue.getValue(),
                       paramType);
             }
           }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMG.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMG.java
@@ -49,8 +49,8 @@ public class SMG implements UnmodifiableSMG {
   private NeqRelation neq = new NeqRelation();
   private PersistentMultimap<SMGObject, SMGObject> possibleEquals;
 
-  private final SMGPredRelation pathPredicate = new SMGPredRelation();
-  private SMGPredRelation errorPredicate = new SMGPredRelation();
+  private final SMGPredicateRelation pathPredicate = new SMGPredicateRelation();
+  private SMGPredicateRelation errorPredicate = new SMGPredicateRelation();
 
   private final MachineModel machine_model;
 
@@ -323,17 +323,17 @@ public class SMG implements UnmodifiableSMG {
   }
 
   @Override
-  public SMGPredRelation getPathPredicateRelation() {
+  public SMGPredicateRelation getPathPredicateRelation() {
     return pathPredicate;
   }
 
   @Override
-  public SMGPredRelation getErrorPredicateRelation() {
+  public SMGPredicateRelation getErrorPredicateRelation() {
     return errorPredicate;
   }
 
   public void resetErrorRelation() {
-    errorPredicate = new SMGPredRelation();
+    errorPredicate = new SMGPredicateRelation();
   }
 
   /* ********************************************* */

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMG.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMG.java
@@ -49,9 +49,8 @@ public class SMG implements UnmodifiableSMG {
   private NeqRelation neq = new NeqRelation();
   private PersistentMultimap<SMGObject, SMGObject> possibleEquals;
 
-  private final PredRelation pathPredicate = new PredRelation();
-  private PredRelation errorPredicate = new PredRelation();
-
+  private final SMGPredRelation pathPredicate = new SMGPredRelation();
+  private SMGPredRelation errorPredicate = new SMGPredRelation();
 
   private final MachineModel machine_model;
 
@@ -324,17 +323,17 @@ public class SMG implements UnmodifiableSMG {
   }
 
   @Override
-  public PredRelation getPathPredicateRelation() {
+  public SMGPredRelation getPathPredicateRelation() {
     return pathPredicate;
   }
 
   @Override
-  public PredRelation getErrorPredicateRelation() {
+  public SMGPredRelation getErrorPredicateRelation() {
     return errorPredicate;
   }
 
   public void resetErrorRelation() {
-    errorPredicate = new PredRelation();
+    errorPredicate = new SMGPredRelation();
   }
 
   /* ********************************************* */

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGPredRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGPredRelation.java
@@ -11,9 +11,7 @@ package org.sosy_lab.cpachecker.cpa.smg.graphs;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
@@ -25,7 +23,7 @@ import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.util.Pair;
 
-public final class PredRelation {
+public final class SMGPredRelation {
   /** The Multimap is used as Bi-Map, i.e. each pair (K,V) is also inserted as pair (V,K). */
   private final SetMultimap<Pair<SMGValue, SMGValue>, SymbolicRelation> smgValuesRelation =
       HashMultimap.create();
@@ -33,27 +31,19 @@ public final class PredRelation {
   private final SetMultimap<SMGValue, SMGValue> smgValuesDependency = HashMultimap.create();
   private final SetMultimap<SMGValue, ExplicitRelation> smgExplicitValueRelation =
       HashMultimap.create();
-  private final Map<SMGValue, Integer> smgValueSizeInBits = new HashMap<>();
-  private final Map<SMGValue, Boolean> smgValueSigned = new HashMap<>();
 
   /** Copy PredRelation */
-  public void putAll(PredRelation pPred) {
+  public void putAll(SMGPredRelation pPred) {
     smgValuesRelation.putAll(pPred.smgValuesRelation);
     smgValuesDependency.putAll(pPred.smgValuesDependency);
     smgExplicitValueRelation.putAll(pPred.smgExplicitValueRelation);
-    smgValueSizeInBits.putAll(pPred.smgValueSizeInBits);
-    smgValueSigned.putAll(pPred.smgValueSigned);
   }
 
   public void addRelation(
       SMGSymbolicValue pOne,
-      int pSize1,
-      boolean pIsSigned1,
-      boolean pIsCast1,
+      SMGType pSMGTypeOne,
       SMGSymbolicValue pTwo,
-      int pSize2,
-      boolean pIsSigned2,
-      boolean pIsCast2,
+      SMGType pSMGTypeTwo,
       BinaryOperator pOperator) {
     // TODO: track address values
     if (!pOne.isUnknown()
@@ -61,32 +51,26 @@ public final class PredRelation {
         && !(pOne instanceof SMGKnownAddressValue)
         && !(pTwo instanceof SMGKnownAddressValue)) {
       if (!pOne.isZero() && !pTwo.isZero()) {
-        addRelation(pOne, pTwo, pOperator);
-        addValueSize(pOne, pSize1, pIsSigned1, pIsCast1);
-        addValueSize(pTwo, pSize2, pIsSigned2, pIsCast2);
+        addSymbolicRelation(pOne, pSMGTypeOne, pTwo, pSMGTypeTwo, pOperator);
       }
       if (pOne.isZero() && !pTwo.isZero()) {
-        addExplicitRelation(pTwo, SMGZeroValue.INSTANCE, pOperator.getOppositLogicalOperator());
-        addValueSize(pTwo, pSize2, pIsSigned2, pIsCast2);
+        addExplicitRelation(
+            pTwo, pSMGTypeTwo, SMGZeroValue.INSTANCE, pOperator.getOppositLogicalOperator());
       }
       if (pTwo.isZero() && !pOne.isZero()) {
-          addExplicitRelation(pOne, SMGZeroValue.INSTANCE, pOperator);
-        addValueSize(pOne, pSize1, pIsSigned1, pIsCast1);
+        addExplicitRelation(pOne, pSMGTypeOne, SMGZeroValue.INSTANCE, pOperator);
       }
     }
   }
 
-  private void addValueSize(SMGValue pValue, Integer pCType, boolean isSigned, boolean isCast) {
-    if (!smgValueSizeInBits.containsKey(pValue)) {
-      smgValueSizeInBits.put(pValue, pCType);
-      smgValueSigned.put(pValue, isSigned);
-    } else {
-      assert smgValueSizeInBits.get(pValue).equals(pCType) || isCast;
-    }
-  }
-
-  public void addRelation(SMGValue pOne, SMGValue pTwo, BinaryOperator pOperator) {
-    SymbolicRelation relation = new SymbolicRelation(pOne, pTwo, pOperator);
+  public void addSymbolicRelation(
+      SMGValue pOne,
+      SMGType pSMGTypeOne,
+      SMGValue pTwo,
+      SMGType pSMGTypeTwo,
+      BinaryOperator pOperator) {
+    SymbolicRelation relation =
+        new SymbolicRelation(pOne, pSMGTypeOne, pTwo, pSMGTypeTwo, pOperator);
     if (!smgValuesDependency.containsEntry(pOne, pTwo)) {
       smgValuesRelation.put(Pair.of(pOne, pTwo), relation);
       smgValuesRelation.put(Pair.of(pTwo, pOne), relation);
@@ -102,23 +86,15 @@ public final class PredRelation {
 
   public void addExplicitRelation(
       SMGSymbolicValue pSymbolicValue,
-      Integer pCType1,
-      boolean pSinged,
+      SMGType pSymbolicSMGType,
       SMGExplicitValue pExplicitValue,
-      Integer pCType2,
       BinaryOperator pOp) {
-    assert(pCType1.equals(pCType2));
     if (!(pSymbolicValue.isZero() && pExplicitValue.isZero())) {
-      addExplicitRelation(pSymbolicValue, pExplicitValue, pOp);
-      addValueSize(pSymbolicValue, pCType1, pSinged, false);
-    }
-  }
-
-  public void addExplicitRelation(
-      SMGValue pSymbolicValue, SMGExplicitValue pExplicitValue, BinaryOperator pOp) {
-    ExplicitRelation relation = new ExplicitRelation(pSymbolicValue, pExplicitValue, pOp);
-    if (!smgExplicitValueRelation.containsEntry(pSymbolicValue, relation)) {
-      smgExplicitValueRelation.put(pSymbolicValue, relation);
+      ExplicitRelation relation =
+          new ExplicitRelation(pSymbolicValue, pSymbolicSMGType, pExplicitValue, pOp);
+      if (!smgExplicitValueRelation.containsEntry(pSymbolicValue, relation)) {
+        smgExplicitValueRelation.put(pSymbolicValue, relation);
+      }
     }
   }
 
@@ -131,7 +107,6 @@ public final class PredRelation {
       smgValuesRelation.removeAll(Pair.of(pValue, pOposit));
     }
     smgExplicitValueRelation.removeAll(pValue);
-    smgValueSizeInBits.remove(pValue);
   }
 
   /** replace the old value with a fresh value. */
@@ -139,28 +114,22 @@ public final class PredRelation {
     for (SMGValue relatedValue : smgValuesDependency.removeAll(old)) {
       smgValuesDependency.remove(relatedValue, old);
       smgValuesRelation.removeAll(Pair.of(old, relatedValue));
-        //TODO: modify predicates on merge values
+      // TODO: modify predicates on merge values
       smgValuesRelation.removeAll(Pair.of(relatedValue, old));
     }
     for (ExplicitRelation explicitRelation: smgExplicitValueRelation.removeAll(old)) {
       if (!fresh.isZero()) {
-        addExplicitRelation(fresh, explicitRelation.explicitValue, explicitRelation.getOperator());
-        addValueSize(fresh, getSymbolicSize(old), isSymbolicSigned(old), false);
+        addExplicitRelation(
+            (SMGSymbolicValue) fresh,
+            explicitRelation.getSymbolicSMGType(),
+            explicitRelation.explicitValue,
+            explicitRelation.getOperator());
       }
     }
-    smgValueSizeInBits.remove(old);
-  }
-
-  public boolean isSymbolicSigned(SMGValue pValue) {
-    return smgValueSigned.get(pValue);
-  }
-
-  public Integer getSymbolicSize(SMGValue pSymbolic) {
-    return smgValueSizeInBits.get(pSymbolic);
   }
 
   /** Returns closure list of symbolic values which affects pRelation */
-  public Set<SMGValue> closureDependencyFor(PredRelation pRelation) {
+  public Set<SMGValue> closureDependencyFor(SMGPredRelation pRelation) {
     Set<SMGValue> toAdd = new HashSet<>();
     for (Entry<SMGValue, SMGValue> entry : pRelation.smgValuesDependency.entries()) {
       SMGValue key = entry.getKey();
@@ -192,13 +161,12 @@ public final class PredRelation {
     return smgValuesRelation.hashCode();
   }
 
-
   @Override
   public boolean equals(Object obj) {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    PredRelation other = (PredRelation) obj;
+    SMGPredRelation other = (SMGPredRelation) obj;
     return other.smgValuesRelation != null && smgValuesRelation.equals(other.smgValuesRelation);
   }
 
@@ -219,7 +187,7 @@ public final class PredRelation {
     return smgValuesRelation.entries();
   }
 
-  public boolean isLessOrEqual(PredRelation pPathPredicateRelation) {
+  public boolean isLessOrEqual(SMGPredRelation pPathPredicateRelation) {
     if (smgValuesDependency.size() > pPathPredicateRelation.smgValuesDependency.size()) {
       return false;
     }
@@ -242,13 +210,22 @@ public final class PredRelation {
   }
 
   static public class SymbolicRelation {
-    final SMGValue valueOne;
-    SMGValue valueTwo;
-    BinaryOperator operator;
+    private SMGValue valueOne;
+    private SMGType firstValSMGType;
+    private SMGValue valueTwo;
+    private SMGType secondValSMGType;
+    private BinaryOperator operator;
 
-    public SymbolicRelation(SMGValue pValueOne, SMGValue pValueTwo, BinaryOperator pOperator) {
+    public SymbolicRelation(
+        SMGValue pValueOne,
+        SMGType pFirstValSMGType,
+        SMGValue pValueTwo,
+        SMGType pSecondValSMGType,
+        BinaryOperator pOperator) {
       valueOne = pValueOne;
+      firstValSMGType = pFirstValSMGType;
       valueTwo = pValueTwo;
+      secondValSMGType = pSecondValSMGType;
       operator = pOperator;
     }
 
@@ -286,23 +263,38 @@ public final class PredRelation {
 
     @Override
     public String toString() {
-      return "SymbolicRelation{" +
-          "symbolicValue1=" + valueOne +
-          ", symbolicValue2=" + valueTwo +
-          ", operator=" + operator +
-          '}';
+      return "SymbolicRelation{"
+          + "symbolicValue1="
+          + valueOne
+          + ", symbolicValue2="
+          + valueTwo
+          + ", operator="
+          + operator
+          + '}';
+    }
+
+    public SMGType getFirstValSMGType() {
+      return firstValSMGType;
+    }
+
+    public SMGType getSecondValSMGType() {
+      return secondValSMGType;
     }
   }
 
-
-  static public class ExplicitRelation {
-    SMGValue symbolicValue;
-    SMGExplicitValue explicitValue;
-    BinaryOperator operator;
+  public static class ExplicitRelation {
+    private SMGValue symbolicValue;
+    private SMGType symbolicSMGType;
+    private SMGExplicitValue explicitValue;
+    private BinaryOperator operator;
 
     public ExplicitRelation(
-        SMGValue pSymbolicValue, SMGExplicitValue pExplicitValue, BinaryOperator pOperator) {
+        SMGValue pSymbolicValue,
+        SMGType pSymbolicSMGType,
+        SMGExplicitValue pExplicitValue,
+        BinaryOperator pOperator) {
       symbolicValue = pSymbolicValue;
+      symbolicSMGType = pSymbolicSMGType;
       explicitValue = pExplicitValue;
       operator = pOperator;
     }
@@ -341,11 +333,18 @@ public final class PredRelation {
 
     @Override
     public String toString() {
-      return "ExplicitRelation{" +
-          "symbolicValue=" + symbolicValue +
-          ", explicitValue=" + explicitValue +
-          ", operator=" + operator +
-          '}';
+      return "ExplicitRelation{"
+          + "symbolicValue="
+          + symbolicValue
+          + ", explicitValue="
+          + explicitValue
+          + ", operator="
+          + operator
+          + '}';
+    }
+
+    public SMGType getSymbolicSMGType() {
+      return symbolicSMGType;
     }
   }
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGPredicateRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGPredicateRelation.java
@@ -8,7 +8,7 @@
 
 package org.sosy_lab.cpachecker.cpa.smg.graphs;
 
-                                                                                                                                                                  import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import java.util.Collection;
 import java.util.HashSet;
@@ -17,8 +17,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.sosy_lab.cpachecker.cfa.ast.c.CBinaryExpression.BinaryOperator;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
-                                                                                                                                                                  import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
-                                                                                                                                                                  import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
+import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.util.Pair;
@@ -41,9 +40,9 @@ public final class SMGPredicateRelation {
   }
 
   public void addRelation(
-      SMGSymbolicValue pOne,
+      SMGValue pOne,
       SMGType pSMGTypeOne,
-      SMGSymbolicValue pTwo,
+      SMGValue pTwo,
       SMGType pSMGTypeTwo,
       BinaryOperator pOperator) {
     // TODO: track address values
@@ -86,7 +85,7 @@ public final class SMGPredicateRelation {
   }
 
   public void addExplicitRelation(
-      SMGSymbolicValue pSymbolicValue,
+      SMGValue pSymbolicValue,
       SMGType pSymbolicSMGType,
       SMGExplicitValue pExplicitValue,
       BinaryOperator pOp) {
@@ -121,7 +120,7 @@ public final class SMGPredicateRelation {
     for (ExplicitRelation explicitRelation: smgExplicitValueRelation.removeAll(old)) {
       if (!fresh.isZero()) {
         addExplicitRelation(
-            (SMGSymbolicValue) fresh,
+            fresh,
             explicitRelation.getSymbolicSMGType(),
             explicitRelation.explicitValue,
             explicitRelation.getOperator());
@@ -208,6 +207,10 @@ public final class SMGPredicateRelation {
       return false;
     }
     return true;
+  }
+
+  public boolean hasRelation(SMGValue pSymbolicValue) {
+    return smgValuesDependency.containsKey(pSymbolicValue);
   }
 
   static public class SymbolicRelation {

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGPredicateRelation.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGPredicateRelation.java
@@ -8,7 +8,7 @@
 
 package org.sosy_lab.cpachecker.cpa.smg.graphs;
 
-import com.google.common.collect.HashMultimap;
+                                                                                                                                                                  import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import java.util.Collection;
 import java.util.HashSet;
@@ -17,13 +17,14 @@ import java.util.Objects;
 import java.util.Set;
 import org.sosy_lab.cpachecker.cfa.ast.c.CBinaryExpression.BinaryOperator;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGExplicitValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
-import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
+                                                                                                                                                                  import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGKnownAddressValue;
+                                                                                                                                                                  import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGSymbolicValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGValue;
 import org.sosy_lab.cpachecker.cpa.smg.graphs.value.SMGZeroValue;
 import org.sosy_lab.cpachecker.util.Pair;
 
-public final class SMGPredRelation {
+/** Utility class for representation comparisons of SMGValues */
+public final class SMGPredicateRelation {
   /** The Multimap is used as Bi-Map, i.e. each pair (K,V) is also inserted as pair (V,K). */
   private final SetMultimap<Pair<SMGValue, SMGValue>, SymbolicRelation> smgValuesRelation =
       HashMultimap.create();
@@ -33,7 +34,7 @@ public final class SMGPredRelation {
       HashMultimap.create();
 
   /** Copy PredRelation */
-  public void putAll(SMGPredRelation pPred) {
+  public void putAll(SMGPredicateRelation pPred) {
     smgValuesRelation.putAll(pPred.smgValuesRelation);
     smgValuesDependency.putAll(pPred.smgValuesDependency);
     smgExplicitValueRelation.putAll(pPred.smgExplicitValueRelation);
@@ -129,7 +130,7 @@ public final class SMGPredRelation {
   }
 
   /** Returns closure list of symbolic values which affects pRelation */
-  public Set<SMGValue> closureDependencyFor(SMGPredRelation pRelation) {
+  public Set<SMGValue> closureDependencyFor(SMGPredicateRelation pRelation) {
     Set<SMGValue> toAdd = new HashSet<>();
     for (Entry<SMGValue, SMGValue> entry : pRelation.smgValuesDependency.entries()) {
       SMGValue key = entry.getKey();
@@ -166,7 +167,7 @@ public final class SMGPredRelation {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    SMGPredRelation other = (SMGPredRelation) obj;
+    SMGPredicateRelation other = (SMGPredicateRelation) obj;
     return other.smgValuesRelation != null && smgValuesRelation.equals(other.smgValuesRelation);
   }
 
@@ -187,7 +188,7 @@ public final class SMGPredRelation {
     return smgValuesRelation.entries();
   }
 
-  public boolean isLessOrEqual(SMGPredRelation pPathPredicateRelation) {
+  public boolean isLessOrEqual(SMGPredicateRelation pPathPredicateRelation) {
     if (smgValuesDependency.size() > pPathPredicateRelation.smgValuesDependency.size()) {
       return false;
     }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGType.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGType.java
@@ -15,54 +15,56 @@ import org.sosy_lab.cpachecker.cpa.smg.SMGState;
 import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGExpressionEvaluator;
 import org.sosy_lab.cpachecker.exceptions.UnrecognizedCodeException;
 
+/** Class for representation of casting values to different types for SMG predicate relations */
 public class SMGType {
-  private int size;
-  private boolean isSigned;
+  private int castedSize;
+  private boolean castedSigned;
   private int originSize;
-  private boolean isOriginSigned;
+  private boolean originSigned;
 
-  private SMGType(int pSize, boolean pIsSigned, int pOriginSize, boolean pIsOriginSigned) {
-    size = pSize;
-    isSigned = pIsSigned;
+  private SMGType(int pCastedSize, boolean pCastedSigned, int pOriginSize, boolean pOriginSigned) {
+    castedSize = pCastedSize;
+    castedSigned = pCastedSigned;
     originSize = pOriginSize;
-    isOriginSigned = pIsOriginSigned;
+    originSigned = pOriginSigned;
   }
 
-  public SMGType(int pSize, boolean pIsSigneds) {
-    this(pSize, pIsSigneds, pSize, pIsSigneds);
+  public SMGType(int pCastedSize, boolean pSigned) {
+    this(pCastedSize, pSigned, pCastedSize, pSigned);
   }
 
-  public SMGType(SMGType pType, SMGType pOriginType) {
-    this(pType.getSize(), pType.isSigned(), pOriginType.getOriginSize(), pOriginType.isSigned());
+  public SMGType(SMGType pCastedType, SMGType pOriginType) {
+    this(
+        pCastedType.getCastedSize(),
+        pCastedType.isCastedSigned(),
+        pOriginType.getOriginSize(),
+        pOriginType.isCastedSigned());
   }
 
   public static SMGType constructSMGType(
-      CType leftSideType,
-      SMGState newState,
-      CFAEdge edge,
-      SMGExpressionEvaluator smgExpressionEvaluator)
+      CType pType, SMGState pState, CFAEdge pEdge, SMGExpressionEvaluator smgExpressionEvaluator)
       throws UnrecognizedCodeException {
-    boolean isSignedLeft = false;
-    if (leftSideType instanceof CSimpleType) {
-      isSignedLeft = newState.getHeap().getMachineModel().isSigned((CSimpleType) leftSideType);
+    boolean isSigned = false;
+    if (pType instanceof CSimpleType) {
+      isSigned = pState.getHeap().getMachineModel().isSigned((CSimpleType) pType);
     }
-    int leftSideTypeSize = smgExpressionEvaluator.getBitSizeof(edge, leftSideType, newState);
-    return new SMGType(leftSideTypeSize, isSignedLeft);
+    int size = smgExpressionEvaluator.getBitSizeof(pEdge, pType, pState);
+    return new SMGType(size, isSigned);
   }
 
-  public int getSize() {
-    return size;
+  public int getCastedSize() {
+    return castedSize;
   }
 
-  public boolean isSigned() {
-    return isSigned;
+  public boolean isCastedSigned() {
+    return castedSigned;
   }
 
   public int getOriginSize() {
     return originSize;
   }
 
-  public boolean getOriginSigned() {
-    return isOriginSigned;
+  public boolean isOriginSigned() {
+    return originSigned;
   }
 }

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGType.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGType.java
@@ -1,0 +1,68 @@
+// This file is part of CPAchecker,
+// a tool for configurable software verification:
+// https://cpachecker.sosy-lab.org
+//
+// SPDX-FileCopyrightText: 2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.cpachecker.cpa.smg.graphs;
+
+import org.sosy_lab.cpachecker.cfa.model.CFAEdge;
+import org.sosy_lab.cpachecker.cfa.types.c.CSimpleType;
+import org.sosy_lab.cpachecker.cfa.types.c.CType;
+import org.sosy_lab.cpachecker.cpa.smg.SMGState;
+import org.sosy_lab.cpachecker.cpa.smg.evaluator.SMGExpressionEvaluator;
+import org.sosy_lab.cpachecker.exceptions.UnrecognizedCodeException;
+
+public class SMGType {
+  private int size;
+  private boolean isSigned;
+  private int originSize;
+  private boolean isOriginSigned;
+
+  private SMGType(int pSize, boolean pIsSigned, int pOriginSize, boolean pIsOriginSigned) {
+    size = pSize;
+    isSigned = pIsSigned;
+    originSize = pOriginSize;
+    isOriginSigned = pIsOriginSigned;
+  }
+
+  public SMGType(int pSize, boolean pIsSigneds) {
+    this(pSize, pIsSigneds, pSize, pIsSigneds);
+  }
+
+  public SMGType(SMGType pType, SMGType pOriginType) {
+    this(pType.getSize(), pType.isSigned(), pOriginType.getOriginSize(), pOriginType.isSigned());
+  }
+
+  public static SMGType constructSMGType(
+      CType leftSideType,
+      SMGState newState,
+      CFAEdge edge,
+      SMGExpressionEvaluator smgExpressionEvaluator)
+      throws UnrecognizedCodeException {
+    boolean isSignedLeft = false;
+    if (leftSideType instanceof CSimpleType) {
+      isSignedLeft = newState.getHeap().getMachineModel().isSigned((CSimpleType) leftSideType);
+    }
+    int leftSideTypeSize = smgExpressionEvaluator.getBitSizeof(edge, leftSideType, newState);
+    return new SMGType(leftSideTypeSize, isSignedLeft);
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public boolean isSigned() {
+    return isSigned;
+  }
+
+  public int getOriginSize() {
+    return originSize;
+  }
+
+  public boolean getOriginSigned() {
+    return isOriginSigned;
+  }
+}

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGType.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/SMGType.java
@@ -17,10 +17,10 @@ import org.sosy_lab.cpachecker.exceptions.UnrecognizedCodeException;
 
 /** Class for representation of casting values to different types for SMG predicate relations */
 public class SMGType {
-  private int castedSize;
-  private boolean castedSigned;
-  private int originSize;
-  private boolean originSigned;
+  private final int castedSize;
+  private final boolean castedSigned;
+  private final int originSize;
+  private final boolean originSigned;
 
   private SMGType(int pCastedSize, boolean pCastedSigned, int pOriginSize, boolean pOriginSigned) {
     castedSize = pCastedSize;

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/UnmodifiableSMG.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/UnmodifiableSMG.java
@@ -33,9 +33,9 @@ public interface UnmodifiableSMG {
    */
   SMG copyOf();
 
-  PredRelation getPathPredicateRelation();
+  SMGPredRelation getPathPredicateRelation();
 
-  PredRelation getErrorPredicateRelation();
+  SMGPredRelation getErrorPredicateRelation();
 
   PersistentSet<SMGValue> getValues();
 

--- a/src/org/sosy_lab/cpachecker/cpa/smg/graphs/UnmodifiableSMG.java
+++ b/src/org/sosy_lab/cpachecker/cpa/smg/graphs/UnmodifiableSMG.java
@@ -33,9 +33,9 @@ public interface UnmodifiableSMG {
    */
   SMG copyOf();
 
-  SMGPredRelation getPathPredicateRelation();
+  SMGPredicateRelation getPathPredicateRelation();
 
-  SMGPredRelation getErrorPredicateRelation();
+  SMGPredicateRelation getErrorPredicateRelation();
 
   PersistentSet<SMGValue> getValues();
 

--- a/test/programs/smg_predicates/linux_ptr_err.c
+++ b/test/programs/smg_predicates/linux_ptr_err.c
@@ -1,0 +1,80 @@
+typedef _Bool bool;
+typedef unsigned long __kernel_ulong_t;
+typedef __kernel_ulong_t __kernel_size_t;
+typedef __kernel_size_t size_t;
+void *__devm_regmap_init_i2c(void);
+void __VERIFIER_assume(int);
+static bool IS_ERR(void const *ptr);
+static long PTR_ERR(void const *ptr);
+char *r;
+
+void *ldv_reference_malloc(size_t size)
+{
+  void *res;
+  res = malloc(size);
+    __VERIFIER_assume(res != (void *)0);
+    return res;
+}
+
+void *ldv_malloc(size_t size)
+{
+  void *res;
+  res = ldv_reference_malloc(size);
+  if (res != (void *)0) {
+    __VERIFIER_assume(ldv_is_err((void const *)res) == 0L);
+  }
+  return res;
+}
+static int sx9500_probe() {
+//  void *data = __devm_regmap_init_i2c();
+  void *data = 18446744073709547522UL;
+  if (ldv_is_err(data))
+    return ldv_ptr_err(data);
+  r = ldv_malloc(1);
+  return 0;
+}
+
+//static int ldv_filter_positive_int(int val)
+//{
+//  __VERIFIER_assume(val <= 0);
+//  return val;
+//}
+//
+//int ldv_post_probe(int probe_ret_val) {
+//  return ldv_filter_positive_int(probe_ret_val);
+//}
+
+int main() {
+  int emg_7_probe_retval = sx9500_probe();
+//  emg_7_probe_retval = ldv_post_probe(emg_7_probe_retval);
+  if (ldv_undef_int()) {
+    __VERIFIER_assume(emg_7_probe_retval == 0);
+    r[1] = 1;
+    free(r);
+  } else {
+    __VERIFIER_assume(emg_7_probe_retval != 0);
+  }
+}
+
+long ldv_is_err(void const *ptr)
+{
+  return (long)((unsigned long)ptr > 18446744073709547521UL);
+}
+
+long ldv_ptr_err(void const *ptr)
+{
+  __VERIFIER_assume((unsigned long)ptr > 18446744073709547521UL);
+  return (long)(18446744073709547521UL - (unsigned long)ptr);
+}
+
+static bool IS_ERR(void const *ptr)
+{
+  long ret;
+  ret = ldv_is_err(ptr);
+  return (_Bool)(ret != 0L);
+}
+
+static long PTR_ERR(void const *ptr)
+{
+  return ldv_ptr_err(ptr);
+}

--- a/test/programs/smg_predicates/linux_ptr_err.c
+++ b/test/programs/smg_predicates/linux_ptr_err.c
@@ -1,3 +1,11 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 typedef _Bool bool;
 typedef unsigned long __kernel_ulong_t;
 typedef __kernel_ulong_t __kernel_size_t;
@@ -26,7 +34,6 @@ void *ldv_malloc(size_t size)
   return res;
 }
 static int sx9500_probe() {
-//  void *data = __devm_regmap_init_i2c();
   void *data = 18446744073709547522UL;
   if (ldv_is_err(data))
     return ldv_ptr_err(data);
@@ -34,19 +41,8 @@ static int sx9500_probe() {
   return 0;
 }
 
-//static int ldv_filter_positive_int(int val)
-//{
-//  __VERIFIER_assume(val <= 0);
-//  return val;
-//}
-//
-//int ldv_post_probe(int probe_ret_val) {
-//  return ldv_filter_positive_int(probe_ret_val);
-//}
-
 int main() {
   int emg_7_probe_retval = sx9500_probe();
-//  emg_7_probe_retval = ldv_post_probe(emg_7_probe_retval);
   if (ldv_undef_int()) {
     __VERIFIER_assume(emg_7_probe_retval == 0);
     r[1] = 1;

--- a/test/programs/smg_predicates/linux_ptr_err.c
+++ b/test/programs/smg_predicates/linux_ptr_err.c
@@ -30,7 +30,7 @@ static int sx9500_probe() {
   void *data = 18446744073709547522UL;
   if (ldv_is_err(data))
     return ldv_ptr_err(data);
-  r = ldv_malloc(1);
+  r = ldv_malloc(2);
   return 0;
 }
 

--- a/test/programs/smg_predicates/linux_ptr_err.yml
+++ b/test/programs/smg_predicates/linux_ptr_err.yml
@@ -1,0 +1,15 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+format_version: '1.0'
+
+input_files: 'linux_ptr_err.c'
+
+properties:
+  - property_file: ../../config/properties/valid-memsafety.prp
+    expected_verdict: true

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic.c
@@ -1,3 +1,11 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 typedef _Bool bool;
 typedef unsigned long __kernel_ulong_t;
 typedef __kernel_ulong_t __kernel_size_t;

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic.c
@@ -1,10 +1,10 @@
-# This file is part of CPAchecker,
-# a tool for configurable software verification:
-# https://cpachecker.sosy-lab.org
-#
-# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
-#
-# SPDX-License-Identifier: Apache-2.0
+// This file is part of CPAchecker,
+// a tool for configurable software verification:
+// https://cpachecker.sosy-lab.org
+//
+// SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 typedef _Bool bool;
 typedef unsigned long __kernel_ulong_t;

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic.c
@@ -1,0 +1,80 @@
+typedef _Bool bool;
+typedef unsigned long __kernel_ulong_t;
+typedef __kernel_ulong_t __kernel_size_t;
+typedef __kernel_size_t size_t;
+void *__devm_regmap_init_i2c(void);
+void __VERIFIER_assume(int);
+static bool IS_ERR(void const *ptr);
+static long PTR_ERR(void const *ptr);
+char *r;
+
+void *ldv_reference_malloc(size_t size)
+{
+  void *res;
+  res = malloc(size);
+    __VERIFIER_assume(res != (void *)0);
+    return res;
+}
+
+void *ldv_malloc(size_t size)
+{
+  void *res;
+  res = ldv_reference_malloc(size);
+  if (res != (void *)0) {
+    __VERIFIER_assume(ldv_is_err((void const *)res) == 0L);
+  }
+  return res;
+}
+static int sx9500_probe() {
+  void *data = __devm_regmap_init_i2c();
+//  void *data = 18446744073709547522UL;
+  if (ldv_is_err(data))
+    return ldv_ptr_err(data);
+  r = ldv_malloc(1);
+  return 0;
+}
+
+//static int ldv_filter_positive_int(int val)
+//{
+//  __VERIFIER_assume(val <= 0);
+//  return val;
+//}
+//
+//int ldv_post_probe(int probe_ret_val) {
+//  return ldv_filter_positive_int(probe_ret_val);
+//}
+
+int main() {
+  int emg_7_probe_retval = sx9500_probe();
+//  emg_7_probe_retval = ldv_post_probe(emg_7_probe_retval);
+  if (ldv_undef_int()) {
+    __VERIFIER_assume(emg_7_probe_retval == 0);
+    r[1] = 1;
+    free(r);
+  } else {
+    __VERIFIER_assume(emg_7_probe_retval != 0);
+  }
+}
+
+long ldv_is_err(void const *ptr)
+{
+  return (long)((unsigned long)ptr > 18446744073709547521UL);
+}
+
+long ldv_ptr_err(void const *ptr)
+{
+  __VERIFIER_assume((unsigned long)ptr > 18446744073709547521UL);
+  return (long)(18446744073709547521UL - (unsigned long)ptr);
+}
+
+static bool IS_ERR(void const *ptr)
+{
+  long ret;
+  ret = ldv_is_err(ptr);
+  return (_Bool)(ret != 0L);
+}
+
+static long PTR_ERR(void const *ptr)
+{
+  return ldv_ptr_err(ptr);
+}

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic.yml
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic.yml
@@ -1,0 +1,15 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+format_version: '1.0'
+
+input_files: 'linux_ptr_err_symbolic.c'
+
+properties:
+  - property_file: ../../config/properties/valid-memsafety.prp
+    expected_verdict: true

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.c
@@ -1,3 +1,11 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 typedef _Bool bool;
 typedef unsigned long __kernel_ulong_t;
 typedef __kernel_ulong_t __kernel_size_t;

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.c
@@ -1,10 +1,10 @@
-# This file is part of CPAchecker,
-# a tool for configurable software verification:
-# https://cpachecker.sosy-lab.org
-#
-# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
-#
-# SPDX-License-Identifier: Apache-2.0
+// This file is part of CPAchecker,
+// a tool for configurable software verification:
+// https://cpachecker.sosy-lab.org
+//
+// SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
 
 typedef _Bool bool;
 typedef unsigned long __kernel_ulong_t;

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.c
@@ -46,13 +46,19 @@ int main() {
 
 long ldv_is_err(void const *ptr)
 {
-  return (long)((unsigned long)ptr > 18446744073709547521UL);
+  if ((unsigned long)ptr > 18446744073709547521UL) {
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 long ldv_ptr_err(void const *ptr)
 {
   __VERIFIER_assume((unsigned long)ptr > 18446744073709547521UL);
-  return (long)(18446744073709547521UL - (unsigned long)ptr);
+  long result = (long)(18446744073709547521UL - (unsigned long)ptr);
+  __VERIFIER_assume(result != 0);
+  return result;
 }
 
 static bool IS_ERR(void const *ptr)

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.yml
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround.yml
@@ -1,0 +1,15 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+format_version: '1.0'
+
+input_files: 'linux_ptr_err_symbolic_workaround.c'
+
+properties:
+  - property_file: ../../config/properties/valid-memsafety.prp
+    expected_verdict: true

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast.c
@@ -34,7 +34,7 @@ void *ldv_malloc(size_t size)
   return res;
 }
 static int sx9500_probe() {
-  void *data = 18446744073709547522UL;
+  void *data = __devm_regmap_init_i2c();
   if (ldv_is_err(data))
     return ldv_ptr_err(data);
   r = ldv_malloc(2);
@@ -54,13 +54,19 @@ int main() {
 
 long ldv_is_err(void const *ptr)
 {
-  return (long)((unsigned long)ptr > 18446744073709547521UL);
+  if ((unsigned long)(char*)(long)ptr > 18446744073709547521UL) {
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 long ldv_ptr_err(void const *ptr)
 {
   __VERIFIER_assume((unsigned long)ptr > 18446744073709547521UL);
-  return (long)(18446744073709547521UL - (unsigned long)ptr);
+  long result = (long)(18446744073709547521UL - (unsigned long)(long)(char*)ptr);
+  __VERIFIER_assume(result != 0);
+  return result;
 }
 
 static bool IS_ERR(void const *ptr)

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast.yml
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast.yml
@@ -1,0 +1,15 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+format_version: '1.0'
+
+input_files: 'linux_ptr_err_symbolic_workaround_recursive_cast.c'
+
+properties:
+  - property_file: ../../config/properties/valid-memsafety.prp
+    expected_verdict: true

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast2.c
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast2.c
@@ -1,0 +1,70 @@
+// This file is part of CPAchecker,
+// a tool for configurable software verification:
+// https://cpachecker.sosy-lab.org
+//
+// SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+typedef _Bool bool;
+typedef unsigned long __kernel_ulong_t;
+typedef __kernel_ulong_t __kernel_size_t;
+typedef __kernel_size_t size_t;
+void *__devm_regmap_init_i2c(void);
+void __VERIFIER_assume(int);
+static bool IS_ERR(void const *ptr);
+static long PTR_ERR(void const *ptr);
+char *r;
+
+void *ldv_reference_malloc(size_t size)
+{
+  void *res;
+  res = malloc(size);
+    __VERIFIER_assume(res != (void *)0);
+    return res;
+}
+
+void *ldv_malloc(size_t size)
+{
+  void *res;
+  res = ldv_reference_malloc(size);
+  if (res != (void *)0) {
+    __VERIFIER_assume(ldv_is_err((void const *)res) == 0L);
+  }
+  return res;
+}
+static int sx9500_probe() {
+  void *data = __devm_regmap_init_i2c();
+  if (ldv_is_err(data))
+    return ldv_ptr_err(data);
+  r = ldv_malloc(2);
+  return 0;
+}
+
+int main() {
+  int emg_7_probe_retval = sx9500_probe();
+  if (emg_7_probe_retval == 0) {
+    r[1] = 1;
+    free(r);
+  } else {
+    //unreached path
+    r = ldv_malloc(2);
+  }
+}
+
+long ldv_is_err(void const *ptr)
+{
+  if ((unsigned long)(unsigned char)(long)ptr > 1000UL) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+long ldv_ptr_err(void const *ptr)
+{
+  __VERIFIER_assume((unsigned long)ptr > 1000UL);
+  long result = (long)(1000UL - (unsigned long)(long)(char*)ptr);
+  __VERIFIER_assume(result != 0);
+  return result;
+}

--- a/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast2.yml
+++ b/test/programs/smg_predicates/linux_ptr_err_symbolic_workaround_recursive_cast2.yml
@@ -1,0 +1,15 @@
+# This file is part of CPAchecker,
+# a tool for configurable software verification:
+# https://cpachecker.sosy-lab.org
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+format_version: '1.0'
+
+input_files: 'linux_ptr_err_symbolic_workaround_recursive_cast2.c'
+
+properties:
+  - property_file: ../../config/properties/valid-memsafety.prp
+    expected_verdict: true


### PR DESCRIPTION
Add casting into SMG predicate extension under smg-ldv configuration to avoid illegal_exception on formula creation.
Also support pointer casting and comparison as ulong for IS_ERR(), ERR_PTR(), PTR_ERR() Linux macros